### PR TITLE
Add basic navbar and footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,15 @@
 import { Theme } from "@radix-ui/themes";
-// ...
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pt">
       <body>
         <Theme>
+          <Navbar />
           {children}
+          <Footer />
         </Theme>
       </body>
     </html>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="border-t p-4 mt-8 text-center text-sm">
+      <p>&copy; {new Date().getFullYear()} CEAD. Todos os direitos reservados.</p>
+    </footer>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+export default function Navbar() {
+  return (
+    <nav className="border-b p-4">
+      <div className="container mx-auto flex items-center justify-between">
+        <Link href="/home" className="text-xl font-bold">
+          CEAD
+        </Link>
+        <ul className="flex gap-4">
+          <li>
+            <Link href="/home" className="hover:underline">
+              Home
+            </Link>
+          </li>
+          <li>
+            <Link href="/sobre" className="hover:underline">
+              Sobre
+            </Link>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple Navbar with links to Home and Sobre pages
- add a Footer with copyright
- wrap pages with Navbar and Footer in the root layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ff3529908832c860272bb09729bd4