### PR TITLE
Add Serviço and Contato pages and update navbar

### DIFF
--- a/src/app/contato/page.tsx
+++ b/src/app/contato/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { Button } from "@radix-ui/themes";
+
+export default function ContatoPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6">
+      <h1 className="text-5xl font-extrabold bg-gradient-to-r from-[#09009f] to-[#00ff95] bg-clip-text text-transparent">
+        Contato
+      </h1>
+      <p className="max-w-xl text-center">
+        Fale conosco para saber mais sobre nossos serviços.
+      </p>
+      <Link href="/home">
+        <Button variant="outline">Voltar para Home</Button>
+      </Link>
+    </main>
+  );
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -4,10 +4,20 @@ import { Button } from "@radix-ui/themes";
 export default function HomePage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6">
-      <h1 className="text-4xl font-bold">Bem-vindo à Home!</h1>
-      <Link href="/sobre">
-        <Button>Sobre nós</Button>
-      </Link>
+      <h1 className="text-5xl font-extrabold bg-gradient-to-r from-[#09009f] to-[#00ff95] bg-clip-text text-transparent">
+        Bem-vindo à Home!
+      </h1>
+      <div className="flex gap-4">
+        <Link href="/sobre">
+          <Button>Sobre nós</Button>
+        </Link>
+        <Link href="/servicos">
+          <Button variant="outline">Serviços</Button>
+        </Link>
+        <Link href="/contato">
+          <Button variant="outline">Contato</Button>
+        </Link>
+      </div>
     </main>
   );
 }

--- a/src/app/servicos/page.tsx
+++ b/src/app/servicos/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { Button } from "@radix-ui/themes";
+
+export default function ServicosPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6">
+      <h1 className="text-5xl font-extrabold bg-gradient-to-r from-[#09009f] to-[#00ff95] bg-clip-text text-transparent">
+        Serviços
+      </h1>
+      <p className="max-w-xl text-center">
+        Conheça os serviços oferecidos pela CEAD.
+      </p>
+      <Link href="/contato">
+        <Button variant="outline">Entre em contato</Button>
+      </Link>
+    </main>
+  );
+}

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@radix-ui/themes";
 export default function SobrePage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6">
-      <h1 className="text-4xl font-bold">Sobre nós</h1>
+      <h1 className="text-5xl font-extrabold bg-gradient-to-r from-[#09009f] to-[#00ff95] bg-clip-text text-transparent">Sobre nós</h1>
       <p className="max-w-xl text-center">
         Esta é a página “Sobre”, organizada com App Router.
       </p>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,12 +2,12 @@ import Link from 'next/link';
 
 export default function Navbar() {
   return (
-    <nav className="border-b p-4">
-      <div className="container mx-auto flex items-center justify-between">
+    <header className="sticky top-0 left-0 z-10 p-4">
+      <nav className="mx-auto flex max-w-5xl items-center justify-between rounded-full bg-[rgba(76,76,76,0.36)] px-6 py-3 backdrop-blur text-white">
         <Link href="/home" className="text-xl font-bold">
           CEAD
         </Link>
-        <ul className="flex gap-4">
+        <ul className="flex gap-6 font-semibold">
           <li>
             <Link href="/home" className="hover:underline">
               Home
@@ -18,8 +18,18 @@ export default function Navbar() {
               Sobre
             </Link>
           </li>
+          <li>
+            <Link href="/servicos" className="hover:underline">
+              Serviços
+            </Link>
+          </li>
+          <li>
+            <Link href="/contato" className="hover:underline">
+              Contato
+            </Link>
+          </li>
         </ul>
-      </div>
-    </nav>
+      </nav>
+    </header>
   );
 }


### PR DESCRIPTION
## Summary
- update `Navbar` styling and add links for new pages
- apply gradient styling across pages
- add new `/servicos` and `/contato` routes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ff9923178832cbc0fe8ab2d36efbd